### PR TITLE
docs: add extension-token integrator endpoint

### DIFF
--- a/docs/account/extension-token.md
+++ b/docs/account/extension-token.md
@@ -1,0 +1,66 @@
+---
+id: extension-token
+title: Token de conexão via extensão
+---
+
+## Método
+
+`GET` https://api.plugchat.com.br/integrator/account/[ID_DA_CONTA]/extension-token
+
+---
+
+## Conceituação
+
+Neste método você pode gerar um código de conexão para vincular o WhatsApp da conta através da extensão de navegador **Whats Conector** (Z-API), sem a necessidade de ler o QR Code.
+
+O código retornado deve ser digitado na extensão e possui um tempo de validade. Após expirar, basta chamar novamente este método para gerar um novo código.
+
+---
+
+:::caution Sobre a URL da API
+
+Observe que a URL da API é composta pelo id da conta do cliente, o mesmo retornado na criação da conta.
+
+:::
+
+## Response
+
+### 200
+
+| Atributos | Tipo | Descrição |
+| :-- | :-- | :-- |
+| token | string | Código de conexão que deve ser digitado na extensão Whats Conector |
+| expiresAt | number | Data/hora de expiração do código em milissegundos (epoch). Após esse instante, gere um novo código |
+
+Exemplo
+
+```json
+{
+  "token": "AB12CD",
+  "expiresAt": 1751385600000
+}
+```
+
+### 404
+
+Retornado quando a conta não é encontrada para o seu integrador ou quando a conta ainda não possui uma instância de WhatsApp associada.
+
+```json
+{
+  "reason": "entity not found"
+}
+```
+
+### 405
+
+Neste caso certifique que esteja enviando corretamente a especificação do método, ou seja verifique se você enviou o GET conforme especificado no início deste tópico.
+
+### 415
+
+Caso você receba um erro 415, certifique de adicionar na headers da requisição o "Content-Type" do objeto que você está enviando, em sua grande maioria "application/json"
+
+---
+
+## Code
+
+<iframe src="//api.apiembed.com/?source=https://raw.githubusercontent.com/fourpixelit/plug-chat-partner-docs/main/json-examples/extension-token.json&targets=all" frameBorder="0" scrolling="no" width="100%" height="500px" seamless></iframe>

--- a/json-examples/extension-token.json
+++ b/json-examples/extension-token.json
@@ -1,0 +1,9 @@
+{
+  "method": "GET",
+  "url": "https://api.plugchat.com.br/integrator/account/[ID_DA_CONTA]/extension-token",
+  "httpVersion": "HTTP/1.1",
+  "queryString": [],
+  "headers": [],
+  "cookies": [],
+  "postData": {}
+}

--- a/sidebars.js
+++ b/sidebars.js
@@ -17,6 +17,7 @@ module.exports = {
       'account/get-account',
       'account/subscription',
       'account/cancel-subscription',
+      'account/extension-token',
     ],
     Departamentos: [
       'departments/introduction',


### PR DESCRIPTION
## Descrição

Adiciona a documentação do novo endpoint de integrador para gerar o token de conexão via extensão de navegador (Whats Conector / Z-API).

`GET https://api.plugchat.com.br/integrator/account/[ID_DA_CONTA]/extension-token`

Retorna `{ token, expiresAt }`, permitindo vincular o WhatsApp da conta sem a necessidade de ler o QR Code.

## Alterações

- `docs/account/extension-token.md` — nova página de documentação (seção **Conta**), seguindo o mesmo padrão das demais páginas (Método, Conceituação, Response 200/404/405/415 e exemplo de código via apiembed).
- `json-examples/extension-token.json` — exemplo de requisição consumido pelo iframe apiembed.
- `sidebars.js` — registra `account/extension-token` na seção **Conta**.

## Observações

- O endpoint correspondente foi implementado na aplicação principal em `src/pages/api/integrator/account/[accountId]/extension-token.ts`.
- Build local do Docusaurus não executado (node_modules ausente); alterações seguem exatamente o template das páginas existentes.